### PR TITLE
Do not store Production/Development settings

### DIFF
--- a/00-Starter-Seed/.gitignore
+++ b/00-Starter-Seed/.gitignore
@@ -232,3 +232,6 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# Production/Development appsettings
+appsettings.*.json

--- a/01-Authentication-RS256/.gitignore
+++ b/01-Authentication-RS256/.gitignore
@@ -232,3 +232,6 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# Production/Development appsettings
+appsettings.*.json

--- a/02-Authentication-HS256/.gitignore
+++ b/02-Authentication-HS256/.gitignore
@@ -232,3 +232,6 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# Production/Development appsettings
+appsettings.*.json

--- a/03-Authorization/.gitignore
+++ b/03-Authorization/.gitignore
@@ -232,3 +232,6 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# Production/Development appsettings
+appsettings.*.json


### PR DESCRIPTION
Adds rules to exclude Production and Development
application settings configuration from storing
in the repository. That way developers can store
their Auth0 information in environment dependant
configuration files.
https://docs.asp.net/en/latest/fundamentals/environments.html

Thanks!
