### PR TITLE
Add Routing package 1.0.1 dependency

### DIFF
--- a/00-Starter-Seed/project.json
+++ b/00-Starter-Seed/project.json
@@ -5,6 +5,7 @@
       "type": "platform"
     },
     "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Routing": "1.0.1",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",

--- a/01-Authentication-RS256/project.json
+++ b/01-Authentication-RS256/project.json
@@ -5,6 +5,7 @@
       "type": "platform"
     },
     "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Routing": "1.0.1",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",

--- a/02-Authentication-HS256/project.json
+++ b/02-Authentication-HS256/project.json
@@ -5,6 +5,7 @@
       "type": "platform"
     },
     "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Routing": "1.0.1",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",

--- a/03-Authorization/project.json
+++ b/03-Authorization/project.json
@@ -5,6 +5,7 @@
       "type": "platform"
     },
     "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Routing": "1.0.1",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",


### PR DESCRIPTION
This commit puts examples in sync with current post-1.0.1 update
tooling templates - including one available with generator-aspnet.
See:
https://github.com/aspnet/Templates/commit/2018df76027942f43b5723ca5f344f5e86d62a13

Thanks!
