### PR TITLE
[SDK-1965] Update quickstart and sample applications

### DIFF
--- a/Quickstart/00-Starter-Seed/Dockerfile
+++ b/Quickstart/00-Starter-Seed/Dockerfile
@@ -2,8 +2,7 @@
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
 WORKDIR /app
-EXPOSE 80
-EXPOSE 443
+EXPOSE 5000
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src

--- a/Quickstart/00-Starter-Seed/README.md
+++ b/Quickstart/00-Starter-Seed/README.md
@@ -35,4 +35,4 @@ Execute in command line `sh exec.sh` to run the Docker in Linux or macOS, or `.\
 
 ## Calling the API
 
-Go to `http://localhost:3010/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:3010/api/private` endpoint.
+Go to `http://localhost:5000/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:5000/api/private` endpoint.

--- a/Quickstart/00-Starter-Seed/appsettings.json
+++ b/Quickstart/00-Starter-Seed/appsettings.json
@@ -7,6 +7,7 @@
       "Microsoft": "Information"
     }
   },
+  "Urls": "http://localhost:5000",
   "Auth0": {
     "Domain": "YOUR_AUTH0_DOMAIN",
     "Audience": "YOUR_UNIQUE_IDENTIFIER"

--- a/Quickstart/00-Starter-Seed/appsettings.json
+++ b/Quickstart/00-Starter-Seed/appsettings.json
@@ -7,7 +7,13 @@
       "Microsoft": "Information"
     }
   },
-  "Urls": "http://localhost:5000",
+  "kestrel": {
+    "EndPoints": {
+      "Http": {
+        "Url": "http://*:5000"
+      }
+    }
+  },
   "Auth0": {
     "Domain": "YOUR_AUTH0_DOMAIN",
     "Audience": "YOUR_UNIQUE_IDENTIFIER"

--- a/Quickstart/00-Starter-Seed/exec.ps1
+++ b/Quickstart/00-Starter-Seed/exec.ps1
@@ -1,2 +1,2 @@
 docker build -t auth0-aspnetcore-00-rs256 .
-docker run --rm -p 3010:80 --name auth0-aspnetcore-00-rs256 -it auth0-aspnetcore-00-rs256
+docker run --rm -p 5000:5000 --name auth0-aspnetcore-00-rs256 -it auth0-aspnetcore-00-rs256

--- a/Quickstart/00-Starter-Seed/exec.sh
+++ b/Quickstart/00-Starter-Seed/exec.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 docker build -t auth0-aspnetcore-00-rs256 .
-docker run --rm -p 3010:80 --name auth0-aspnetcore-00-rs256 -it auth0-aspnetcore-00-rs256
+docker run --rm -p 5000:5000 --name auth0-aspnetcore-00-rs256 -it auth0-aspnetcore-00-rs256
 

--- a/Quickstart/01-Authorization/Dockerfile
+++ b/Quickstart/01-Authorization/Dockerfile
@@ -2,8 +2,7 @@
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
 WORKDIR /app
-EXPOSE 80
-EXPOSE 443
+EXPOSE 5000
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src

--- a/Quickstart/01-Authorization/README.md
+++ b/Quickstart/01-Authorization/README.md
@@ -35,7 +35,7 @@ Execute in command line `sh exec.sh` to run the Docker in Linux or macOS, or `.\
 
 ## Calling the API
 
-Go to `http://localhost:3010/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:3010/api/private` endpoint.
+Go to `http://localhost:5000/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:5000/api/private` endpoint.
 
 ## Important Snippets
 
@@ -53,7 +53,7 @@ public void ConfigureServices(IServiceCollection services)
 			builder =>
 			{
 				builder
-				.WithOrigins("http://localhost:5000")
+				.WithOrigins("http://localhost:8080")
 				.AllowAnyMethod()
 				.AllowAnyHeader()
 				.AllowCredentials();

--- a/Quickstart/01-Authorization/appsettings.json
+++ b/Quickstart/01-Authorization/appsettings.json
@@ -7,6 +7,7 @@
       "Microsoft": "Information"
     }
   },
+  "Urls": "http://localhost:5000",
   "Auth0": {
     "Domain": "YOUR_AUTH0_DOMAIN",
     "Audience": "YOUR_UNIQUE_IDENTIFIER"

--- a/Quickstart/01-Authorization/appsettings.json
+++ b/Quickstart/01-Authorization/appsettings.json
@@ -7,7 +7,13 @@
       "Microsoft": "Information"
     }
   },
-  "Urls": "http://localhost:5000",
+  "kestrel": {
+    "EndPoints": {
+      "Http": {
+        "Url": "http://*:5000"
+      }
+    }
+  },
   "Auth0": {
     "Domain": "YOUR_AUTH0_DOMAIN",
     "Audience": "YOUR_UNIQUE_IDENTIFIER"

--- a/Quickstart/01-Authorization/exec.ps1
+++ b/Quickstart/01-Authorization/exec.ps1
@@ -1,2 +1,2 @@
 docker build -t auth0-aspnetcore-01-rs256 .
-docker run --rm -p 3010:80 --name auth0-aspnetcore-01-rs256 -it auth0-aspnetcore-01-rs256
+docker run --rm -p 5000:5000 --name auth0-aspnetcore-01-rs256 -it auth0-aspnetcore-01-rs256

--- a/Quickstart/01-Authorization/exec.sh
+++ b/Quickstart/01-Authorization/exec.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 docker build -t auth0-aspnetcore-01-rs256 .
-docker run --rm -p 3010:80 --name auth0-aspnetcore-01-rs256 -it auth0-aspnetcore-01-rs256
+docker run --rm -p 5000:5000 --name auth0-aspnetcore-01-rs256 -it auth0-aspnetcore-01-rs256

--- a/Samples/hs256/Dockerfile
+++ b/Samples/hs256/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
 WORKDIR /app
-EXPOSE 80
+EXPOSE 5000
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src

--- a/Samples/hs256/README.md
+++ b/Samples/hs256/README.md
@@ -1,4 +1,4 @@
-# Authenticate with JWT (RS256)
+# Authenticate with JWT (HS256)
 
 This example shows how to authenticate a user using a JSON Web Token (JWT) which is signed using HS256.
 

--- a/Samples/hs256/README.md
+++ b/Samples/hs256/README.md
@@ -1,8 +1,6 @@
 # Authenticate with JWT (RS256)
 
-This example shows how to authenticate a user using a JSON Web Token (JWT) which is signed using RS256.
-
-You can read a quickstart for this sample [here](https://auth0.com/docs/quickstart/backend/aspnet-core-webapi/01-authentication-rs256). 
+This example shows how to authenticate a user using a JSON Web Token (JWT) which is signed using HS256.
 
 ## To run this project
 
@@ -36,11 +34,11 @@ Execute in command line `sh exec.sh` to run the Docker in Linux or macOS, or `.\
 
 ## Calling the API
 
-Go to `http://localhost:3010/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:3010/api/private` endpoint.
+Go to `http://localhost:5000/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:5000/api/private` endpoint.
 
 ## Important Snippets
 
-### 1. Register Authenticatio Services
+### 1. Register Authentication Services
 
 ```csharp
 // Startup.cs
@@ -77,26 +75,12 @@ public void ConfigureServices(IServiceCollection services)
 
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 {
-	if (env.IsDevelopment())
-	{
-		app.UseDeveloperExceptionPage();
-	}
-	else
-	{
-		app.UseHsts();
-	}
-
-	app.UseHttpsRedirection();
-
-	app.UseRouting();
+	// ...
 
 	app.UseAuthentication();
 	app.UseAuthorization();
 
-	app.UseEndpoints(endpoints =>
-	{
-		endpoints.MapControllers();
-	});
+	// ...
 }
 ```
 

--- a/Samples/hs256/appsettings.json
+++ b/Samples/hs256/appsettings.json
@@ -7,7 +7,13 @@
       "Microsoft": "Information"
     }
   },
-  "Urls": "http://localhost:5000",
+  "kestrel": {
+    "EndPoints": {
+      "Http": {
+        "Url": "http://*:5000"
+      }
+    }
+  },
   "Auth0": {
     "Domain": "YOUR_AUTH0_DOMAIN",
     "Audience": "YOUR_UNIQUE_IDENTIFIER",

--- a/Samples/hs256/appsettings.json
+++ b/Samples/hs256/appsettings.json
@@ -7,6 +7,7 @@
       "Microsoft": "Information"
     }
   },
+  "Urls": "http://localhost:5000",
   "Auth0": {
     "Domain": "YOUR_AUTH0_DOMAIN",
     "Audience": "YOUR_UNIQUE_IDENTIFIER",

--- a/Samples/hs256/exec.ps1
+++ b/Samples/hs256/exec.ps1
@@ -1,2 +1,2 @@
 docker build -t auth0-aspnetcore-hs256 .
-docker run --rm -p 3010:80 --name auth0-aspnetcore-hs256 -it auth0-aspnetcore-hs256
+docker run --rm -p 5000:5000 --name auth0-aspnetcore-hs256 -it auth0-aspnetcore-hs256

--- a/Samples/hs256/exec.sh
+++ b/Samples/hs256/exec.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 docker build -t auth0-aspnetcore-hs256 .
-docker run --rm -p 3010:80 --name auth0-aspnetcore-hs256 -it auth0-aspnetcore-hs256
+docker run --rm -p 5000:5000 --name auth0-aspnetcore-hs256 -it auth0-aspnetcore-hs256

--- a/Samples/multiple-issuer/README.md
+++ b/Samples/multiple-issuer/README.md
@@ -1,4 +1,4 @@
-# Authenticate with JWT (RS256)
+# Authenticate with JWT from Multiple Issuers
 
 This example shows how to configure the JWT middleware when handling tokens coming from multiple issuers. 
 
@@ -22,7 +22,7 @@ Execute in command line `sh exec.sh` to run the Docker in Linux or macOS, or `.\
 
 ## Calling the API
 
-Go to `http://localhost:3010/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:3010/api/private` endpoint.
+Go to `http://localhost:5000/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:5000/api/private` endpoint.
 
 ## Important Snippets
 


### PR DESCRIPTION
- The readme was using port 3010 but none of the applications actually used port 3010. 
- Renamed RS to HS in HS256 Sample app
- Fixed a typo