### PR TITLE
Revert port to use 3010 for samples

### DIFF
--- a/Quickstart/00-Starter-Seed/Dockerfile
+++ b/Quickstart/00-Starter-Seed/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
 WORKDIR /app
-EXPOSE 5000
+EXPOSE 3010
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src

--- a/Quickstart/00-Starter-Seed/Properties/launchSettings.json
+++ b/Quickstart/00-Starter-Seed/Properties/launchSettings.json
@@ -8,7 +8,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "http://localhost:3010"
     },
     "Docker": {
       "commandName": "Docker",

--- a/Quickstart/00-Starter-Seed/README.md
+++ b/Quickstart/00-Starter-Seed/README.md
@@ -35,4 +35,4 @@ Execute in command line `sh exec.sh` to run the Docker in Linux or macOS, or `.\
 
 ## Calling the API
 
-Go to `http://localhost:5000/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:5000/api/private` endpoint.
+Go to `http://localhost:3010/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:3010/api/private` endpoint.

--- a/Quickstart/00-Starter-Seed/appsettings.json
+++ b/Quickstart/00-Starter-Seed/appsettings.json
@@ -10,7 +10,7 @@
   "kestrel": {
     "EndPoints": {
       "Http": {
-        "Url": "http://*:5000"
+        "Url": "http://*:3010"
       }
     }
   },

--- a/Quickstart/00-Starter-Seed/exec.ps1
+++ b/Quickstart/00-Starter-Seed/exec.ps1
@@ -1,2 +1,2 @@
 docker build -t auth0-aspnetcore-00-rs256 .
-docker run --rm -p 5000:5000 --name auth0-aspnetcore-00-rs256 -it auth0-aspnetcore-00-rs256
+docker run --rm -p 3010:3010 --name auth0-aspnetcore-00-rs256 -it auth0-aspnetcore-00-rs256

--- a/Quickstart/00-Starter-Seed/exec.sh
+++ b/Quickstart/00-Starter-Seed/exec.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 docker build -t auth0-aspnetcore-00-rs256 .
-docker run --rm -p 5000:5000 --name auth0-aspnetcore-00-rs256 -it auth0-aspnetcore-00-rs256
+docker run --rm -p 3010:3010 --name auth0-aspnetcore-00-rs256 -it auth0-aspnetcore-00-rs256
 

--- a/Quickstart/01-Authorization/Dockerfile
+++ b/Quickstart/01-Authorization/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
 WORKDIR /app
-EXPOSE 5000
+EXPOSE 3010
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src

--- a/Quickstart/01-Authorization/Properties/launchSettings.json
+++ b/Quickstart/01-Authorization/Properties/launchSettings.json
@@ -8,7 +8,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "http://localhost:3010"
     },
     "Docker": {
       "commandName": "Docker",

--- a/Quickstart/01-Authorization/README.md
+++ b/Quickstart/01-Authorization/README.md
@@ -35,7 +35,7 @@ Execute in command line `sh exec.sh` to run the Docker in Linux or macOS, or `.\
 
 ## Calling the API
 
-Go to `http://localhost:5000/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:5000/api/private` endpoint.
+Go to `http://localhost:3010/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:3010/api/private` endpoint.
 
 ## Important Snippets
 

--- a/Quickstart/01-Authorization/appsettings.json
+++ b/Quickstart/01-Authorization/appsettings.json
@@ -10,7 +10,7 @@
   "kestrel": {
     "EndPoints": {
       "Http": {
-        "Url": "http://*:5000"
+        "Url": "http://*:3010"
       }
     }
   },

--- a/Quickstart/01-Authorization/exec.ps1
+++ b/Quickstart/01-Authorization/exec.ps1
@@ -1,2 +1,2 @@
 docker build -t auth0-aspnetcore-01-rs256 .
-docker run --rm -p 5000:5000 --name auth0-aspnetcore-01-rs256 -it auth0-aspnetcore-01-rs256
+docker run --rm -p 3010:3010 --name auth0-aspnetcore-01-rs256 -it auth0-aspnetcore-01-rs256

--- a/Quickstart/01-Authorization/exec.sh
+++ b/Quickstart/01-Authorization/exec.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 docker build -t auth0-aspnetcore-01-rs256 .
-docker run --rm -p 5000:5000 --name auth0-aspnetcore-01-rs256 -it auth0-aspnetcore-01-rs256
+docker run --rm -p 3010:3010 --name auth0-aspnetcore-01-rs256 -it auth0-aspnetcore-01-rs256

--- a/Samples/hs256/Dockerfile
+++ b/Samples/hs256/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
 WORKDIR /app
-EXPOSE 5000
+EXPOSE 3010
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src

--- a/Samples/hs256/Properties/launchSettings.json
+++ b/Samples/hs256/Properties/launchSettings.json
@@ -8,7 +8,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "http://localhost:3010"
     },
     "Docker": {
       "commandName": "Docker",

--- a/Samples/hs256/README.md
+++ b/Samples/hs256/README.md
@@ -34,7 +34,7 @@ Execute in command line `sh exec.sh` to run the Docker in Linux or macOS, or `.\
 
 ## Calling the API
 
-Go to `http://localhost:5000/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:5000/api/private` endpoint.
+Go to `http://localhost:3010/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:3010/api/private` endpoint.
 
 ## Important Snippets
 

--- a/Samples/hs256/appsettings.json
+++ b/Samples/hs256/appsettings.json
@@ -10,7 +10,7 @@
   "kestrel": {
     "EndPoints": {
       "Http": {
-        "Url": "http://*:5000"
+        "Url": "http://*:3010"
       }
     }
   },

--- a/Samples/hs256/exec.ps1
+++ b/Samples/hs256/exec.ps1
@@ -1,2 +1,2 @@
 docker build -t auth0-aspnetcore-hs256 .
-docker run --rm -p 5000:5000 --name auth0-aspnetcore-hs256 -it auth0-aspnetcore-hs256
+docker run --rm -p 3010:3010 --name auth0-aspnetcore-hs256 -it auth0-aspnetcore-hs256

--- a/Samples/hs256/exec.sh
+++ b/Samples/hs256/exec.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 docker build -t auth0-aspnetcore-hs256 .
-docker run --rm -p 5000:5000 --name auth0-aspnetcore-hs256 -it auth0-aspnetcore-hs256
+docker run --rm -p 3010:3010 --name auth0-aspnetcore-hs256 -it auth0-aspnetcore-hs256

--- a/Samples/multiple-issuer/Properties/launchSettings.json
+++ b/Samples/multiple-issuer/Properties/launchSettings.json
@@ -8,7 +8,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "http://localhost:3010"
     },
     "Docker": {
       "commandName": "Docker",

--- a/Samples/multiple-issuer/README.md
+++ b/Samples/multiple-issuer/README.md
@@ -22,7 +22,7 @@ Execute in command line `sh exec.sh` to run the Docker in Linux or macOS, or `.\
 
 ## Calling the API
 
-Go to `http://localhost:5000/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:5000/api/private` endpoint.
+Go to `http://localhost:3010/api/public` in Postman (or your web browser) to access the ping API endpoint. To access the secure endpoint you will need to [obtain an access token](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) and then pass the access token as a **Bearer** token in the **Authorization** header when calling the `http://localhost:3010/api/private` endpoint.
 
 ## Important Snippets
 

--- a/Samples/user-info/Properties/launchSettings.json
+++ b/Samples/user-info/Properties/launchSettings.json
@@ -8,7 +8,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "http://localhost:3010"
     },
     "Docker": {
       "commandName": "Docker",


### PR DESCRIPTION
This PR reverts the port updates that I did and changes them to be 3010, to align with the quickstart docs.