### PR TITLE
Add nullable to HasScopeHandler.cs

### DIFF
--- a/Quickstart/01-Authorization/HasScopeHandler.cs
+++ b/Quickstart/01-Authorization/HasScopeHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -13,10 +14,10 @@ namespace WebAPIApplication
                 return Task.CompletedTask;
 
             // Split the scopes string into an array
-            var scopes = context.User.FindFirst(c => c.Type == "scope" && c.Issuer == requirement.Issuer).Value.Split(' ');
+            var scopes = context.User.FindFirst(c => c.Type == "scope" && c.Issuer == requirement.Issuer)?.Value.Split(' ');
 
             // Succeed if the scope array contains the required scope
-            if (scopes.Any(s => s == requirement.Scope))
+            if ((scopes ?? Array.Empty<string>()).Any(s => s == requirement.Scope))
                 context.Succeed(requirement);
 
             return Task.CompletedTask;


### PR DESCRIPTION
Hello, I noticed on Auth0 ASP.NET Core sample project doesn't have nullable support for file HasScopeHandler.cs, so I'm edited a few lines of code to support this feature